### PR TITLE
set DATABASE_URL to RDS on EC2 instances

### DIFF
--- a/aws/app/cloudformation.template.yml
+++ b/aws/app/cloudformation.template.yml
@@ -163,6 +163,15 @@ Resources:
           Cpu: {{#if cpu }}{{ cpu }}{{ else }}10{{/if}}
           Essential: true
           Environment:
+            - Name: DATABASE_URL
+              Value:
+                "Fn::Join":
+                  - ""
+                  - - "postgres://{{../../rds.username}}:{{../../rds.password}}@"
+                    - !GetAtt RDS.Endpoint.Address
+                    - ":"
+                    - !GetAtt RDS.Endpoint.Port
+                    - "/{{../../rds.name}}"
           {{#each envs}}
             - Name: {{@key}}
               Value: {{this}}


### PR DESCRIPTION
this fixes setting of the DATABASE_URL in the docker tasks (ie api, and eventually workers) on updates using kes/CloudFormation