### PR TITLE
Add updated_at to Tasks

### DIFF
--- a/db/sql/201807311525_tasks_updated_at.sql
+++ b/db/sql/201807311525_tasks_updated_at.sql
@@ -1,0 +1,6 @@
+--
+-- Name: tasks; Type: COLUMN; Schema: public;
+-- Add column to store updated_at in tasks
+--
+
+ALTER TABLE tasks ADD COLUMN updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now();

--- a/routes/tasks.js
+++ b/routes/tasks.js
@@ -5,7 +5,7 @@ const knex = require('../connection');
 const queryWays = require('../services/query-ways');
 const toGeoJSON = require('../services/osm-data-to-geojson');
 
-const properties = ['id', 'way_id', 'neighbors', 'provinces'];
+const properties = ['id', 'way_id', 'neighbors', 'provinces', 'updated_at'];
 
 async function getNextTask (req, res) {
   const skip = req.query.skip ? req.query.skip.split(',') : [];
@@ -34,6 +34,7 @@ async function getNextTask (req, res) {
     queryWays(knex, ids, true).then(function (ways) {
       return res({
         id: task[0].id,
+        updated_at: task[0].updated_at,
         province: task[0].province,
         data: toGeoJSON(ways)
       }).type('application/json');
@@ -52,6 +53,7 @@ async function getTask (req, res) {
   queryWays(knex, ids, true).then(function (ways) {
     return res({
       id: task[0].id,
+      updated_at: task[0].updated_at,
       data: toGeoJSON(ways)
     }).type('application/json');
   }).catch(function () {


### PR DESCRIPTION
Adds an updated_at column to tasks and returns it with task details. Refs https://github.com/orma/openroads-vn-analytics/issues/444

@geohacker I've created the column to use a default timestamp of `now()` - with this, we shouldn't need to change anything in `tiler` as this column will be populated with the current timestamp by default when the CSV is loaded in. Let me know if you see any problems with this approach.

Also, I wasn't sure if there was a command / process to generate the migration files. Right now, I created this "by hand" - let me know if I should have used a generator to get the comments in some correct format or anything.