### PR TITLE
add /roads/ids endpoint to get all vpromm ids for roads with geometries

### DIFF
--- a/routes/road-ids.js
+++ b/routes/road-ids.js
@@ -1,8 +1,5 @@
 'use strict';
 
-var Boom = require('boom');
-var Promise = require('bluebird');
-
 var knex = require('../connection');
 
 module.exports = [

--- a/routes/road-ids.js
+++ b/routes/road-ids.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var Boom = require('boom');
+var Promise = require('bluebird');
+
+var knex = require('../connection');
+
+module.exports = [
+  {
+    /**
+     * @api {get} /roads/ids List of VProMMs ids with road geometries
+     * @apiGroup Road Ids
+     * @apiName Road Ids
+     * @apiDescription Returns a list of VPromms ids with road geometries
+     * @apiVersion 0.1.0
+     *
+     * @apiExample {curl} Example Usage:
+     *   curl http://localhost:4000/roads/ids
+     * @apiSuccessExample {array} Success-Response:
+     *   ["024BX00040","022BX00029", ...]
+     */
+    
+    method: 'GET',
+    path: '/roads/ids',
+    handler: function(req, res) {
+      knex('current_way_tags')
+        .distinct('v')
+        .select('v')
+        .where('k', 'or_vpromms')
+        .then(vpromms => res(vpromms.map(vpromm => vpromm.v)));
+    }
+  }
+];


### PR DESCRIPTION
cc @geohacker 

Since now roads are added both via RLP uploads as well as directly in iD, we need a different end-point to get current vpromm ids from the `current_ways` table as opposed to just the `road_geometries` table, which we were using earlier.

@geohacker if this looks good, I can go ahead with making the frontend changes to query this new end-point.