### PR TITLE
fixes inconsistencies in RLP data from Android vs iOs

### DIFF
--- a/routes/rlp.js
+++ b/routes/rlp.js
@@ -226,7 +226,7 @@ function getVprommModification(way, roadId) {
 
 function getGeometriesRLPVersion(fileObject) {
   const filenamePatternV1 = /^.*\/RoadPath.*\.csv$/;
-  const filenamePatternV2 = /^.*\/.*_Link_.*_Path_.*\.csv$/;
+  const filenamePatternV2 = /^.*\/.*_Link.*_Path_.*\.csv$/;
 
   if (filenamePatternV1.test(fileObject.path)) return 'v1';
   if (filenamePatternV2.test(fileObject.path)) return 'v2';
@@ -305,7 +305,7 @@ function getPropertiesRLPVersion(fileObject) {
 
   // Some CSV filenames start with "RoadIntervals", others with just "Intervals"
   const filenamePatternV1 = /^.*\/(Road)?Intervals.*\.csv$/;
-  const filenamePatternV2 = /^.*\/.*_Link_.*_Roughness_.*\.csv$/;
+  const filenamePatternV2 = /^.*\/.*_Link.*_Roughness_.*\.csv$/;
 
   if (filenamePatternV1.test(fileObject.path)) return 'v1';
   if (filenamePatternV2.test(fileObject.path)) return 'v2';
@@ -324,6 +324,7 @@ async function propertiesHandler (req, res) {
     .on('entry', async e => {
       try {
         const version = getPropertiesRLPVersion(e);
+        console.log('RLP version', version);
         if (version) {
           const read = await parseProperties(e.path, e, existingRoadIds, version);
           if (read[0] && !read[0].road_id) {
@@ -370,7 +371,7 @@ async function propertiesHandler (req, res) {
           _.isEqual(p.datetime, r.datetime) &&
           p.road_id === r.road_id
         );
-
+        console.log('r', r);
         return match
           ? Promise.resolve()
           : knex.insert({

--- a/services/rlp-geometries.js
+++ b/services/rlp-geometries.js
@@ -61,11 +61,15 @@ function cleanGeometry (points) {
 function getPoint(row, version) {
   if (version === 'v1') return row;
   if (version === 'v2') {
-    let latitudeKey = row.hasOwnProperty('Point_Latidude') ? 'Point_Latidude' : 'Point_Latitude';
+    let rowLower = {};
+    Object.keys(row).forEach(key => {
+      rowLower[key.toLowerCase()] = row[key];
+    });
+    let latitudeKey = row.hasOwnProperty('point_latidude') ? 'point_latidude' : 'point_latitude';
     return {
-      'time': row['Time'],
+      'time': row['time'],
       'latitude': row[latitudeKey],
-      'longitude': row['Point_Longitude']
+      'longitude': row['point_longitude']
     }
   }
   throw new Error('Invalid Version format for geometries');

--- a/services/rlp-geometries.js
+++ b/services/rlp-geometries.js
@@ -65,11 +65,11 @@ function getPoint(row, version) {
     Object.keys(row).forEach(key => {
       rowLower[key.toLowerCase()] = row[key];
     });
-    let latitudeKey = row.hasOwnProperty('point_latidude') ? 'point_latidude' : 'point_latitude';
+    let latitudeKey = rowLower.hasOwnProperty('point_latidude') ? 'point_latidude' : 'point_latitude';
     return {
-      'time': row['time'],
-      'latitude': row[latitudeKey],
-      'longitude': row['point_longitude']
+      'time': rowLower['time'],
+      'latitude': rowLower[latitudeKey],
+      'longitude': rowLower['point_longitude']
     }
   }
   throw new Error('Invalid Version format for geometries');

--- a/services/rlp-properties.js
+++ b/services/rlp-properties.js
@@ -26,30 +26,36 @@ function parseRowV1 (csvRow) {
 function parseRowV2(csvRow) {
   const DATE_STRING_FORMAT = 'HH:mm:ss YYYY-MMMM-DD';
 
+  // convert all column keys to lower-case to avoid inconsistent case between android / ios
+  const csvRowLower = {};
+  Object.keys(csvRow).forEach(key => {
+    csvRowLower[key.toLowerCase()] = csvRow[key];
+  });
+
   // Work-around for "Interval_Start_Latitude" key being sometimes misspelt
-  let startLatitudeKey = 'Interval_Start_Latitude';
-  if (csvRow.hasOwnProperty('Interval_Start_Latidude')) {
-    startLatitudeKey = 'Interval_Start_Latidude';
+  let startLatitudeKey = 'interval_start_latitude';
+  if (csvRowLower.hasOwnProperty('interval_start_latidude')) {
+    startLatitudeKey = 'interval_start_latidude';
   }
   const coord = midpoint(
-    point([Number(csvRow['Interval_Start_Longitude']), Number(csvRow[startLatitudeKey])]),
-    point([Number(csvRow['Interval_End_Longitude']), Number(csvRow['Interval_End_Latitude'])])
+    point([Number(csvRowLower['interval_start_longitude']), Number(csvRowLower[startLatitudeKey])]),
+    point([Number(csvRowLower['interval_end_longitude']), Number(csvRowLower['interval_end_latitude'])])
   );
 
   // If row does not have roughness, return null
-  if (!csvRow.hasOwnProperty('Roughness') || csvRow['Roughness'] === '') {
+  if (!csvRowLower.hasOwnProperty('roughness') || csvRow['roughness'] === '') {
     return null;
   }
 
   const props = {
-    'iri': csvRow['Roughness'],
-    'distance': csvRow['Interval_Length'],
-    'suspension': csvRow['Suspension_Type']
+    'iri': csvRowLower['roughness'],
+    'distance': csvRowLower['interval_length'],
+    'suspension': csvRowLower['suspension_type']
   };
 
   return {
     geom: coord.geometry,
-    datetime: moment(csvRow['Time'], DATE_STRING_FORMAT).toDate(),
+    datetime: moment(csvRowLower['time'], DATE_STRING_FORMAT).toDate(),
     properties: props
   };
 


### PR DESCRIPTION
Two differences in the Android files were causing parsing to fail:

 - column names in the android version are different (i.e. all lower-case as opposed to title case on iOs)
 - CSV Filenames on Android are slightly different - i.e. like `_Link001_` vs `_Link_001_` ..

It's a bit hard to predict these kinds of changes without a formal spec, but this should fix the issues in the android samples.

@geohacker could I ask you to give this a bit of a thorough check and test? Thanks!